### PR TITLE
FIX: swift-doc creates file and directory with unexpected permission …

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #131 by @MattKiazyk.
 - Fixed display of bullet list items in documentation discussion parts.
   #130 by @mattt.
+- Fixed file and directory unexpected permissions.
+  #146 by @niw.
 
 ## [1.0.0-beta.3] - 2020-05-19
 

--- a/Sources/swift-doc/Subcommands/Generate.swift
+++ b/Sources/swift-doc/Subcommands/Generate.swift
@@ -50,7 +50,7 @@ extension SwiftDoc {
       let baseURL = options.baseURL
 
       let outputDirectoryURL = URL(fileURLWithPath: options.output)
-      try fileManager.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true, attributes: fileAttributes)
+      try fileManager.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
 
       do {
         let format = options.format

--- a/Sources/swift-doc/Supporting Types/Page.swift
+++ b/Sources/swift-doc/Supporting Types/Page.swift
@@ -35,12 +35,8 @@ extension Page {
     }
 }
 
-
-
 func writeFile(_ data: Data, to url: URL) throws {
     let fileManager = FileManager.default
-    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: [.posixPermissions: 0o744])
-
+    try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
     try data.write(to: url)
-    try fileManager.setAttributes([.posixPermissions: 0o744], ofItemAtPath: url.path)
 }

--- a/Sources/swift-doc/main.swift
+++ b/Sources/swift-doc/main.swift
@@ -14,7 +14,6 @@ LoggingSystem.bootstrap { label in
 let logger = Logger(label: "org.swiftdoc.swift-doc")
 
 let fileManager = FileManager.default
-let fileAttributes: [FileAttributeKey : Any] = [.posixPermissions: 0o744]
 
 var standardOutput = FileHandle.standardOutput
 var standardError = FileHandle.standardError

--- a/Tests/SwiftDocTests/Helpers/temporaryFile.swift
+++ b/Tests/SwiftDocTests/Helpers/temporaryFile.swift
@@ -2,7 +2,7 @@ import Foundation
 
 func temporaryFile(path: String? = nil, contents: String) throws -> URL {
     let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
-    try FileManager.default.createDirectory(at: temporaryDirectoryURL, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o766])
+    try FileManager.default.createDirectory(at: temporaryDirectoryURL, withIntermediateDirectories: true)
 
     let path = path ?? ProcessInfo.processInfo.globallyUniqueString
     let temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(path)


### PR DESCRIPTION
…(#146)

* FIX: swift-doc creates file and directory with unexpected permission

**Problem**

swift-doc creates file with execution bit, also creates directory
without execution bit.

**Solution**

Remove unexpected permission attributes given to the `FileManager`
and let them to use file system defaults.

* Update changelog.